### PR TITLE
media query for ucsd logo

### DIFF
--- a/index.css
+++ b/index.css
@@ -68,6 +68,11 @@ main hr {
   max-width: 800px;
   margin: 2em auto;
 }
+@media screen and (max-width: 1050px) {
+  .ucsd-fixed {
+    display: none;
+  }
+}
 /* Flex Container */
 .flex-container {
   flex-wrap: wrap;

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
 
     <main>
       <img
+        class="ucsd-fixed"
         src="img/ucsd-default.png"
         style="position: fixed; bottom: 10px; right: 10px; max-width: 100px"
       />


### PR DESCRIPTION
Close #17 
Shows ucsd logo on bottom right of screen if size is greater than 1050 px